### PR TITLE
fix: Fix PowerAuthSharingConfiguration crashing

### DIFF
--- a/example/lib/src/test_screen.dart
+++ b/example/lib/src/test_screen.dart
@@ -90,7 +90,7 @@ class _TestScreenState extends State<PowerAuthTestingScreen> {
         final biometryConfig = PowerAuthBiometryConfiguration();
         final keychainConfig = PowerAuthKeychainConfiguration();
         final clientConfig = PowerAuthClientConfiguration(enableUnsecureTraffic: false);
-        final sharingConfig = PowerAuthSharingConfiguration(appGroup: "group.com.wultra.testGroup", appIdentifier: "SharedInstanceTests", keychainAccessGroup: "fake.accessGroup", sharedMemoryIdentifier: "tst1");
+        final sharingConfig = PowerAuthSharingConfiguration(appGroup: "group.com.wultra.testGroup", appIdentifier: "SharedInstanceTests", keychainAccessGroup: "fake.accessGroup", sharedMemoryIdentifier: "fapp");
 
         await _powerAuth.configure(
           configuration: powerAuthConfig,

--- a/example/lib/tests/suites/powerauth_configure_tests.dart
+++ b/example/lib/tests/suites/powerauth_configure_tests.dart
@@ -277,7 +277,7 @@ class PowerAuthConfigureTests extends TestSuite {
         appGroup: "group.com.wultra.testGroup",
         appIdentifier: "SharedInstanceTests",
         keychainAccessGroup: "fake.accessGroup", // This will work only in simulator
-        sharedMemoryIdentifier: "tst3"
+        sharedMemoryIdentifier: "ft1"
       );
     }
     if (currentTestName == 'testConfigurationWithBiometry' || currentTestName == 'testFullConfiguration') {
@@ -292,7 +292,7 @@ class PowerAuthConfigureTests extends TestSuite {
         appGroup: "group.com.wultra.testGroup",
         appIdentifier: "SharedInstanceTests",
         keychainAccessGroup: "fake.accessGroup", // This will work only in simulator
-        sharedMemoryIdentifier: "tst4"
+        sharedMemoryIdentifier: "ft2"
       );
     }
     await helper.sdk.configure(


### PR DESCRIPTION
This PR implements a proposing fix for an issue with `sharedMemoryIdentifier` space collisions on iOS.
These collisions happen due to a shared memory space attached by the hosting machine kernel to the specified identifier - in our case `tst1` and `tst2`. As they are also used in React Native tests, any concurrent run of Flutter x RN tests will cause a reservation of the memory block, but for a different `instanceID` which then fails assertions in the native PWA SDK, causing crashes.