### PR TITLE
Automatic time sync before token http header gen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 ## TBA
 
 * Updated native PowerAuth Mobile SDK to version 1.9.5.
+* Token-based authentication now automatically synchronizes time if needed.
+* Logging improvements.
 
 ## 1.1.0
 

--- a/android/src/main/kotlin/com/wultra/android/powerauth/flutter/internal/services/PowerAuthService.kt
+++ b/android/src/main/kotlin/com/wultra/android/powerauth/flutter/internal/services/PowerAuthService.kt
@@ -958,24 +958,20 @@ internal class PowerAuthService(
         val tokenName: String = call.getRequiredArgument(TOKEN_NAME)
 
         usePowerAuth(call, result) { sdk ->
-            val token = sdk.tokenStore.getLocalToken(context, tokenName)
 
-            if (token == null) {
-                result.error(
-                    Errors.EC_LOCAL_TOKEN_NOT_AVAILABLE,
-                    "This token is no longer available in the local store.",
-                    null
-                )
-            } else if (token.canGenerateHeader()) {
-                val header = token.generateHeader()
-                result.success(mapOf("key" to header.key, "value" to header.value))
-            } else {
-                result.error(
-                    Errors.EC_CANNOT_GENERATE_TOKEN,
-                    "Cannot generate header for this token.",
-                    null
-                )
-            }
+            sdk.tokenStore.generateAuthorizationHeader(context, tokenName, object: IGenerateTokenHeaderListener {
+                override fun onGenerateTokenHeaderSucceeded(header: PowerAuthAuthorizationHttpHeader) {
+                    result.success(mapOf("key" to header.key, "value" to header.value))
+                }
+
+                override fun onGenerateTokenHeaderFailed(t: Throwable) {
+                    result.error(
+                        Errors.EC_CANNOT_GENERATE_TOKEN,
+                        "Cannot generate header for this token.",
+                        t
+                    )
+                }
+            })
         }
     }
 

--- a/docs/Changelog.md
+++ b/docs/Changelog.md
@@ -2,6 +2,8 @@
 
 ## TBA
 * Updated native PowerAuth Mobile SDK to version 1.9.5.
+* Token-based authentication now automatically synchronizes time if needed (see [Token-Based Authentication](./Token-Based-Authentication.md) for more details)
+* Logging improvements (see [Logging](./Logging.md) for more details)
 
 ## 1.1.0 (August 2025)
 

--- a/docs/Logging.md
+++ b/docs/Logging.md
@@ -80,4 +80,4 @@ await PowerAuthDebug.configureLogging(const PowerAuthLoggingConfig());
 
 ## Read Next
 
-- [Troubleshooting](./Troubleshooting.md)
+- [Time Synchronization](Time-Synchronization.md)

--- a/docs/Time-Synchronization.md
+++ b/docs/Time-Synchronization.md
@@ -12,9 +12,10 @@ final timeService = powerAuthSDK.timeSynchronizationService;
 
 The time is synchronized automatically in the following situations:
 
-- After an activation is created
-- After getting an activation status
-- After receiving any response encrypted with our End-To-End Encryption scheme
+- After an [activation is created](Device-Activation.md)
+- After getting an [activation status](Requesting-Device-Activation-Status.md)
+- After receiving any response encrypted with our [End-To-End Encryption scheme](End-To-End-Encryption.md)
+- After generating an authorization header for a token (see [Token-Based Authentication](Token-Based-Authentication.md) for more details)
 
 <!-- begin box warning -->
 The time synchronization is reset automatically once your application transitions from the background to the foreground.

--- a/docs/Token-Based-Authentication.md
+++ b/docs/Token-Based-Authentication.md
@@ -46,6 +46,9 @@ try {
 }
 ```
 
+If time is not synchronized with the server before the header generation, it will be performed automatically during this call (an HTTP request). 
+This behavior ensures that the generated token is always valid, even if the device's clock is slightly off.
+
 ## Removing Token From the Server
 
 To remove the token from the server, you can use the following code:

--- a/docs/User-Info.md
+++ b/docs/User-Info.md
@@ -82,4 +82,4 @@ Be aware that all properties in the `PowerAuthUserInfo` and `PowerAuthUserAddres
 
 ## Read Next
 
-- [Time Synchronization](Time-Synchronization.md)
+- [Logging](Logging.md)

--- a/example/integration_test/suites/powerauth_token_test.dart
+++ b/example/integration_test/suites/powerauth_token_test.dart
@@ -67,7 +67,7 @@ main() {
           isA<PowerAuthException>().having(
             (e) => e.code,
             "code",
-            PowerAuthErrorCode.localTokenNotAvailable,
+            PowerAuthErrorCode.cannotGenerateToken,
           ),
         ),
       );
@@ -77,7 +77,7 @@ main() {
           isA<PowerAuthException>().having(
             (e) => e.code,
             "code",
-            PowerAuthErrorCode.localTokenNotAvailable,
+            PowerAuthErrorCode.cannotGenerateToken,
           ),
         ),
       );
@@ -158,7 +158,7 @@ main() {
           isA<PowerAuthException>().having(
             (e) => e.code,
             "code",
-            PowerAuthErrorCode.localTokenNotAvailable,
+            PowerAuthErrorCode.cannotGenerateToken,
           ),
         ),
       );
@@ -173,7 +173,7 @@ main() {
           isA<PowerAuthException>().having(
             (e) => e.code,
             "code",
-            PowerAuthErrorCode.localTokenNotAvailable,
+            PowerAuthErrorCode.cannotGenerateToken,
           ),
         ),
       );
@@ -191,6 +191,8 @@ main() {
         return await credentials.knowledge();
       }
 
+      final activationId = await sdk.getActivationIdentifier();
+
       final tokenStore = sdk.tokenStore;
 
       final token1 = await tokenStore.requestAccessToken(t1, t1Cred);
@@ -201,11 +203,21 @@ main() {
       expect(token2.tokenIdentifier, isNotNull);
       expect(token2.tokenName, t2);
 
+      await sdk.timeSynchronizationService.resetTimeSynchronization(); // force time sync
+
       final header1 = await tokenStore.generateHeaderForToken(t1);
       expect(header1.value, isNotNull);
+      final result1 = await helper.verifyToken(header1.value);
+      expect(result1.tokenValid, true);
+      expect(result1.registrationId, activationId);
+      expect(result1.signatureType, 'POSSESSION');
 
       final header2 = await tokenStore.generateHeaderForToken(t2);
       expect(header2.value, isNotNull);
+      final result2 = await helper.verifyToken(header2.value);
+      expect(result2.tokenValid, true);
+      expect(result2.registrationId, activationId);
+      expect(result2.signatureType, 'POSSESSION_KNOWLEDGE');
     });
   });
 }

--- a/example/integration_test/utils/integration_helper.dart
+++ b/example/integration_test/utils/integration_helper.dart
@@ -211,6 +211,16 @@ class IntegrationHelper {
     return SignatureResponse.fromJson(resp);
   }
 
+  Future<TokenResponse> verifyToken(String authHeader) async {
+    final payload = """
+        {
+          "authHeader": "${authHeader.replaceAll("\"", "\\\"")}"
+        }
+        """;
+    final resp = await _makeCall(payload, "${AppConfig.cloudUrl}/v2/token/verify", method: HtptMethod.post);
+    return TokenResponse.fromJson(resp);
+  }
+
   // --- HELPER FUNCTIONS ---
 
   Future<Map<String, dynamic>> callSDKEndpoint(
@@ -392,6 +402,32 @@ class SignatureResponse {
       registrationStatus: json['registrationStatus'],
       signatureType: json['signatureType'],
       remainingAttempts: json['remainingAttempts'],
+    );
+  }
+}
+
+class TokenResponse {
+  final bool tokenValid;
+  final String? userId;
+  final String? registrationId;
+  final String? registrationStatus;
+  final String? signatureType;
+
+  TokenResponse({
+    required this.tokenValid,
+    required this.userId,
+    required this.registrationId,
+    required this.registrationStatus,
+    required this.signatureType
+  });
+
+  factory TokenResponse.fromJson(Map<String, dynamic> json) {
+    return TokenResponse(
+      tokenValid: json['tokenValid'],
+      userId: json['userId'],
+      registrationId: json['registrationId'],
+      registrationStatus: json['registrationStatus'],
+      signatureType: json['signatureType']
     );
   }
 }

--- a/example/lib/tests/utils/integration_helper.dart
+++ b/example/lib/tests/utils/integration_helper.dart
@@ -142,6 +142,16 @@ class IntegrationHelper {
     return SignatureResponse.fromJson(resp);
   }
 
+  Future<SignatureResponse> verifyToken(String authHeader) async {
+    final payload = """
+        {
+          "authHeader": "${authHeader.replaceAll("\"", "\\\"")}"
+        }
+        """;
+    final resp = await _makeCall(payload, "${AppConfig.cloudUrl}/v2/token/verify", method: HtptMethod.post);
+    return SignatureResponse.fromJson(resp);
+  }
+
   // --- HELPER FUNCTIONS ---
 
   Future<Map<String, dynamic>> callSDKEndpoint(String endpoint, String body, Map<String, String>? headers) async {
@@ -318,6 +328,32 @@ class SignatureResponse {
       registrationStatus: json['registrationStatus'],
       signatureType: json['signatureType'],
       remainingAttempts: json['remainingAttempts']
+    );
+  }
+}
+
+class TokenResponse {
+  final bool tokenValid;
+  final String? userId;
+  final String? registrationId;
+  final String? registrationStatus;
+  final String? signatureType;
+
+  TokenResponse({
+    required this.tokenValid,
+    required this.userId,
+    required this.registrationId,
+    required this.registrationStatus,
+    required this.signatureType
+  });
+
+  factory TokenResponse.fromJson(Map<String, dynamic> json) {
+    return TokenResponse(
+      tokenValid: json['tokenValid'],
+      userId: json['userId'],
+      registrationId: json['registrationId'],
+      registrationStatus: json['registrationStatus'],
+      signatureType: json['signatureType']
     );
   }
 }

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -5,10 +5,10 @@ packages:
     dependency: transitive
     description:
       name: async
-      sha256: d2872f9c19731c2e5f10444b14686eb7cc85c76274bd6c16e1816bff9a3bab63
+      sha256: "758e6d74e971c3e5aceb4110bfd6698efc7f501675bcfe0c775459a8140750eb"
       url: "https://pub.dev"
     source: hosted
-    version: "2.12.0"
+    version: "2.13.0"
   boolean_selector:
     dependency: transitive
     description:
@@ -53,10 +53,10 @@ packages:
     dependency: transitive
     description:
       name: fake_async
-      sha256: "6a95e56b2449df2273fd8c45a662d6947ce1ebb7aafe80e550a3f68297f3cacc"
+      sha256: "5368f224a74523e8d2e7399ea1638b37aecfca824a3cc4dfdf77bf1fa905ac44"
       url: "https://pub.dev"
     source: hosted
-    version: "1.3.2"
+    version: "1.3.3"
   file:
     dependency: transitive
     description:
@@ -133,10 +133,10 @@ packages:
     dependency: transitive
     description:
       name: leak_tracker
-      sha256: c35baad643ba394b40aac41080300150a4f08fd0fd6a10378f8f7c6bc161acec
+      sha256: "6bb818ecbdffe216e81182c2f0714a2e62b593f4a4f13098713ff1685dfb6ab0"
       url: "https://pub.dev"
     source: hosted
-    version: "10.0.8"
+    version: "10.0.9"
   leak_tracker_flutter_testing:
     dependency: transitive
     description:
@@ -298,10 +298,10 @@ packages:
     dependency: transitive
     description:
       name: vm_service
-      sha256: "0968250880a6c5fe7edc067ed0a13d4bae1577fe2771dcf3010d52c4a9d3ca14"
+      sha256: ddfa8d30d89985b96407efce8acbdd124701f96741f2d981ca860662f1c0dc02
       url: "https://pub.dev"
     source: hosted
-    version: "14.3.1"
+    version: "15.0.0"
   web:
     dependency: transitive
     description:
@@ -314,10 +314,10 @@ packages:
     dependency: transitive
     description:
       name: webdriver
-      sha256: "3d773670966f02a646319410766d3b5e1037efb7f07cc68f844d5e06cd4d61c8"
+      sha256: "2f3a14ca026957870cfd9c635b83507e0e51d8091568e90129fbf805aba7cade"
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.4"
+    version: "3.1.0"
 sdks:
   dart: ">=3.7.2 <4.0.0"
   flutter: ">=3.18.0-18.0.pre.54"

--- a/ios/Classes/internal/services/PowerAuthService.swift
+++ b/ios/Classes/internal/services/PowerAuthService.swift
@@ -728,16 +728,17 @@ internal class PowerAuthService: PowerAuthFlutterService {
     private func generateHeaderForToken(_ call: FlutterMethodCall, _ result: @escaping FlutterResult) throws {
         try usePowerAuth(call, result) { sdk, wrap in
             let tokenName: String = try call.requireParameter(Args.tokenName)
-            guard let token = sdk.tokenStore.localToken(withName: tokenName) else {
-                throw PluginException(.localTokenNotAvailable, message: "Token \(tokenName) is no longer available in the local store.")
+            sdk.tokenStore.generateAuthorizationHeader(withName: tokenName) { header, error in
+                wrap {
+                    guard let header else {
+                        throw PluginException(.cannotGenerateToken, message: "Cannot generate header for the token \(tokenName).")
+                    }
+                    result([
+                        "key": header.key,
+                        "value": header.value
+                    ])
+                }
             }
-            guard token.canGenerateHeader, let header = token.generateHeader() else {
-                throw PluginException(.cannotGenerateToken, message: "Cannot generate header for the token \(tokenName).")
-            }
-            result([
-                "key": header.key,
-                "value": header.value
-            ])
         }
     }
     

--- a/lib/src/powerauth/powerauth_token_store.dart
+++ b/lib/src/powerauth/powerauth_token_store.dart
@@ -89,6 +89,8 @@ class PowerAuthTokenStore {
 
     /// Generates a http header for the token in local storage.
     /// 
+    /// If needed, the method automatically performs time synchronization (via additional HTTP request).
+    /// 
     /// @param tokenName Name of token in the local storage that will be used for generating
     /// @returns header or throws
     Future<PowerAuthAuthorizationHttpHeader> generateHeaderForToken(String tokenName) async {


### PR DESCRIPTION
Fixed #56 

- Using `generateAuthorizationHeader` for token authorization headers ensures that the time is synchronized.
- Improved the test to validate the generated headers.
- Docs fixes