### PR TITLE
Bump compile sdk version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## TBA
 
-* TBA
+* Updates minimum supported SDK version to Flutter 3.44/Dart 3.12.
+* Migrates to built-in Kotlin
 
 ## 1.4.0
 

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -12,7 +12,7 @@ buildscript {
     }
 
     dependencies {
-        classpath("com.android.tools.build:gradle:8.7.0")
+        classpath("com.android.tools.build:gradle:9.2.0")
         classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version")
     }
 }
@@ -32,7 +32,7 @@ dependencies {
 android {
     namespace = "com.wultra.android.powerauth.flutter"
 
-    compileSdk = 33
+    compileSdk = 37
 
     compileOptions {
         sourceCompatibility = JavaVersion.VERSION_11

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -10,7 +10,7 @@ buildscript {
     }
 
     dependencies {
-        classpath("com.android.tools.build:gradle:9.2.0")
+        classpath("com.android.tools.build:gradle:9.2.1")
     }
 }
 
@@ -27,18 +27,18 @@ dependencies {
 
 kotlin {
     compilerOptions {
-        jvmTarget = org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_11
+        jvmTarget = org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_17
     }
 }
 
 android {
     namespace = "com.wultra.android.powerauth.flutter"
 
-    compileSdk = 37
+    compileSdk = 36
 
     compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_11
-        targetCompatibility = JavaVersion.VERSION_11
+        sourceCompatibility = JavaVersion.VERSION_17
+        targetCompatibility = JavaVersion.VERSION_17
     }
 
     sourceSets {

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -2,10 +2,8 @@ group = "com.wultra.android.powerauth.flutter"
 version = "0.0.1-alpha"
 
 apply plugin: "com.android.library"
-apply plugin: "kotlin-android"
 
 buildscript {
-    ext.kotlin_version = "1.9.22"
     repositories {
         google()
         mavenCentral()
@@ -13,7 +11,6 @@ buildscript {
 
     dependencies {
         classpath("com.android.tools.build:gradle:9.2.0")
-        classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version")
     }
 }
 
@@ -25,8 +22,13 @@ allprojects {
 }
 
 dependencies {
-    implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
     api "com.wultra.android.powerauth:powerauth-sdk:1.9.5"
+}
+
+kotlin {
+    compilerOptions {
+        jvmTarget = org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_11
+    }
 }
 
 android {
@@ -37,10 +39,6 @@ android {
     compileOptions {
         sourceCompatibility = JavaVersion.VERSION_11
         targetCompatibility = JavaVersion.VERSION_11
-    }
-
-    kotlinOptions {
-        jvmTarget = JavaVersion.VERSION_11
     }
 
     sourceSets {

--- a/docs/Changelog.md
+++ b/docs/Changelog.md
@@ -2,7 +2,8 @@
 
 ## TBA
 
-* TBA
+* Updates minimum supported SDK version to Flutter 3.44/Dart 3.12.
+* Migrates to built-in Kotlin
 
 ## 1.4.0
 

--- a/example/android/app/build.gradle.kts
+++ b/example/android/app/build.gradle.kts
@@ -8,7 +8,7 @@ plugins {
 
 android {
     namespace = "com.wultra.flutter_powerauth_mobile_sdk_plugin_example"
-    compileSdk = flutter.compileSdkVersion
+    compileSdk = 37
     ndkVersion = flutter.ndkVersion
 
     compileOptions {

--- a/example/android/app/build.gradle.kts
+++ b/example/android/app/build.gradle.kts
@@ -1,10 +1,9 @@
 plugins {
     id("com.android.application")
 
-    // The Flutter Gradle Plugin must be applied after the Android and Kotlin Gradle plugins.
+    // The Flutter Gradle Plugin must be applied after the Android plugin.
     id("dev.flutter.flutter-gradle-plugin")
 }
-
 
 kotlin {
     compilerOptions {

--- a/example/android/app/build.gradle.kts
+++ b/example/android/app/build.gradle.kts
@@ -1,23 +1,25 @@
 plugins {
     id("com.android.application")
-    id("kotlin-android")
 
     // The Flutter Gradle Plugin must be applied after the Android and Kotlin Gradle plugins.
     id("dev.flutter.flutter-gradle-plugin")
 }
 
+
+kotlin {
+    compilerOptions {
+        jvmTarget = org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_17
+    }
+}
+
 android {
     namespace = "com.wultra.flutter_powerauth_mobile_sdk_plugin_example"
-    compileSdk = 37
+    compileSdk = 36
     ndkVersion = flutter.ndkVersion
 
     compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_11
-        targetCompatibility = JavaVersion.VERSION_11
-    }
-
-    kotlinOptions {
-        jvmTarget = JavaVersion.VERSION_11.toString()
+        sourceCompatibility = JavaVersion.VERSION_17
+        targetCompatibility = JavaVersion.VERSION_17
     }
 
     defaultConfig {

--- a/example/android/gradle.properties
+++ b/example/android/gradle.properties
@@ -1,3 +1,7 @@
 org.gradle.jvmargs=-Xmx8G -XX:MaxMetaspaceSize=4G -XX:ReservedCodeCacheSize=512m -XX:+HeapDumpOnOutOfMemoryError
 android.useAndroidX=true
 android.enableJetifier=true
+# This builtInKotlin flag was added automatically by Flutter migrator
+android.builtInKotlin=false
+# This newDsl flag was added automatically by Flutter migrator
+android.newDsl=false

--- a/example/android/gradle/wrapper/gradle-wrapper.properties
+++ b/example/android/gradle/wrapper/gradle-wrapper.properties
@@ -2,4 +2,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.10.2-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.4.1-bin.zip

--- a/example/android/gradle/wrapper/gradle-wrapper.properties
+++ b/example/android/gradle/wrapper/gradle-wrapper.properties
@@ -2,4 +2,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-9.4.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.6.1-all.zip

--- a/example/android/settings.gradle.kts
+++ b/example/android/settings.gradle.kts
@@ -19,6 +19,7 @@ pluginManagement {
 plugins {
     id("dev.flutter.flutter-plugin-loader") version "1.0.0"
     id("com.android.application") version "9.2.1" apply false
+    id("org.jetbrains.kotlin.android") version "2.4.0" apply false
 }
 
 include(":app")

--- a/example/android/settings.gradle.kts
+++ b/example/android/settings.gradle.kts
@@ -18,7 +18,7 @@ pluginManagement {
 
 plugins {
     id("dev.flutter.flutter-plugin-loader") version "1.0.0"
-    id("com.android.application") version "8.7.0" apply false
+    id("com.android.application") version "9.2.0" apply false
     id("org.jetbrains.kotlin.android") version "1.8.22" apply false
 }
 

--- a/example/android/settings.gradle.kts
+++ b/example/android/settings.gradle.kts
@@ -18,8 +18,7 @@ pluginManagement {
 
 plugins {
     id("dev.flutter.flutter-plugin-loader") version "1.0.0"
-    id("com.android.application") version "9.2.0" apply false
-    id("org.jetbrains.kotlin.android") version "1.8.22" apply false
+    id("com.android.application") version "9.2.1" apply false
 }
 
 include(":app")

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -319,5 +319,5 @@ packages:
     source: hosted
     version: "3.1.0"
 sdks:
-  dart: ">=3.10.0-0 <4.0.0"
-  flutter: ">=3.18.0-18.0.pre.54"
+  dart: ">=3.12.0 <4.0.0"
+  flutter: ">=3.44.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,8 +4,8 @@ version: 0.0.1-dev
 homepage: https://www.wultra.com/products/mobile-first-authentication
 
 environment:
-  sdk: ^3.7.2
-  flutter: '>=3.3.0'
+  sdk: ^3.12.0
+  flutter: '>=3.44.0'
 
 dependencies:
   flutter:


### PR DESCRIPTION
closes #77 and #84
 
This PR raises compileSdk version to 36, agp version above 9, JVM to 17 and implements environment requirements for flutter 3.44. 
AGP 9 introduces builtInKotlin features which are mandatory, but flutter added a temporary workaround with builtInKotlin = false in settings.gradle. This should make the transformation to builtInKotlin not throw build errors for users in the future.

`builtInKotlin = false` because `builtInKotlin = true` is not supported yet. https://github.com/flutter/flutter/pull/188543
 